### PR TITLE
Add floating word game

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,0 +1,89 @@
+const WORD = 'APPLE';
+const TOTAL_LETTERS = 15;
+const REMOVAL_INTERVAL = 3000; // ms
+
+const container = document.getElementById('letter-container');
+const input = document.getElementById('guess-input');
+const feedback = document.getElementById('feedback');
+input.focus();
+
+function randomInRange(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+function createLetter(char) {
+  const span = document.createElement('span');
+  span.className = 'letter';
+  span.textContent = char;
+  span.style.left = randomInRange(0, 90) + '%';
+  span.style.top = randomInRange(0, 90) + '%';
+  span.style.setProperty('--dx', `${randomInRange(-50, 50)}px`);
+  span.style.setProperty('--dy', `${randomInRange(-50, 50)}px`);
+  span.style.setProperty('--dur', `${randomInRange(4, 8)}s`);
+  return span;
+}
+
+// Prepare letters
+const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+const extras = [];
+const available = alphabet.filter(ch => !WORD.includes(ch));
+while (extras.length < TOTAL_LETTERS - WORD.length) {
+  const idx = Math.floor(Math.random() * available.length);
+  extras.push(available.splice(idx, 1)[0]);
+}
+
+const allLetters = [
+  ...WORD.split('').map(ch => ({ ch, extra: false })),
+  ...extras.map(ch => ({ ch, extra: true }))
+];
+
+// Shuffle letters for display
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+shuffle(allLetters);
+
+const extraElems = [];
+allLetters.forEach(obj => {
+  const el = createLetter(obj.ch);
+  container.appendChild(el);
+  if (obj.extra) extraElems.push(el);
+});
+
+// Remove extraneous letters over time
+shuffle(extraElems);
+let removalIndex = 0;
+const interval = setInterval(() => {
+  if (removalIndex < extraElems.length) {
+    extraElems[removalIndex].remove();
+    removalIndex++;
+  } else {
+    clearInterval(interval);
+  }
+}, REMOVAL_INTERVAL);
+
+function stopGame() {
+  clearInterval(interval);
+  document.querySelectorAll('.letter').forEach(el => {
+    el.style.animationPlayState = 'paused';
+  });
+}
+
+input.addEventListener('keydown', e => {
+  if (e.key === 'Enter') {
+    const guess = input.value.toUpperCase();
+    if (guess.length === WORD.length) {
+      if (guess === WORD) {
+        feedback.textContent = 'You win!';
+        input.disabled = true;
+        stopGame();
+      } else {
+        feedback.textContent = 'Try again!';
+      }
+      input.value = '';
+    }
+  }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Floating Word Game</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Find the Word</h1>
+  <div id="letter-container"></div>
+  <input id="guess-input" type="text" maxlength="5" placeholder="Type word" autocomplete="off" />
+  <div id="feedback"></div>
+  <script src="game.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,66 @@
+body {
+  margin: 0;
+  overflow: hidden;
+  font-family: 'Arial', sans-serif;
+  background: linear-gradient(120deg, #74ebd5, #ACB6E5);
+  color: #fff;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+h1 {
+  margin-top: 20px;
+  font-weight: 300;
+  letter-spacing: 2px;
+}
+
+#letter-container {
+  position: relative;
+  width: 60vmin;
+  height: 60vmin;
+  max-width: 400px;
+  max-height: 400px;
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  border-radius: 20px;
+  overflow: hidden;
+  margin-top: 30px;
+}
+
+#guess-input {
+  margin-top: 20px;
+  padding: 10px;
+  width: 200px;
+  font-size: 1.2rem;
+  text-transform: uppercase;
+  text-align: center;
+  border: none;
+  border-radius: 8px;
+  outline: none;
+}
+
+#feedback {
+  margin-top: 10px;
+  height: 1.5rem;
+  font-weight: 600;
+}
+
+.letter {
+  position: absolute;
+  font-size: 2rem;
+  padding: 10px;
+  user-select: none;
+  pointer-events: none;
+  animation: drift var(--dur) ease-in-out infinite;
+}
+
+@keyframes drift {
+  0%, 100% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(var(--dx), var(--dy));
+  }
+}


### PR DESCRIPTION
## Summary
- create minimal HTML page for word game
- add CSS for gradient background and floating letters
- implement JavaScript to animate letters and remove extras every 3 seconds
- constrain letters to a square container with input field
- evaluate guesses and freeze letters on win

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dec2999c08331aee2fd6214cf650a